### PR TITLE
Change editorGroup.emptyBackground from #181A1F to #0c0c0c

### DIFF
--- a/themes/lukin-color-theme.json
+++ b/themes/lukin-color-theme.json
@@ -694,7 +694,7 @@
     "editor.findMatchHighlightBackground": "#ffffff22",
     "editor.hoverHighlightBackground": "#ffffff22",
     "editorCodeLens.foreground": "#ffffff66",
-    "editorGroup.emptyBackground": "#181A1F",
+    "editorGroup.emptyBackground": "#0c0c0c",
     "editorGroup.border": "#181A1F",
     "editorGroupHeader.tabsBackground": "#000",
     "editorIndentGuide.background": "#ffffff22",


### PR DESCRIPTION
The "editorGroup.emptyBackground" was changed due to an color inconsistency when the editor has nothing opened. I judge this color is more accurate with the color scheme than the old one.
![print](https://i.imgur.com/BcqgYeT.png)
*Original at left, my change at right*

I choose this color because some darker color will hide the VS logo.